### PR TITLE
Only non-global code is type-checked.

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -2,15 +2,20 @@
 
 include dirname(__DIR__) . '/src/app.hh';
 
-$app = new App();
+function run() {
 
-//Vector<string>
-$message = Vector {'H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'};
+    $app = new App();
 
-echo "I would expect this should fail: ". $app->run($message, 99) . '<br />';
+    //Vector<string>
+    $message = Vector {'H', 'E', 'L', 'L', 'O', ' ', 'W', 'O', 'R', 'L', 'D'};
+
+    echo "I would expect this should fail: ". $app->run($message, 99) . '<br />';
 
 
-echo "This should pass: " . $app->runCorrect($message, 99) . '<br />';
+    echo "This should pass: " . $app->runCorrect($message, 99) . '<br />';
 
 
-echo "So why do both work...?";
+    echo "So why do both work...?";
+}
+
+run();


### PR DESCRIPTION
After wrapping the content of `index.php` the type checker shows the error you were expecting.